### PR TITLE
Adapt lss handling

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,7 +34,7 @@ jobs:
         password: ${{ secrets.PYPI_API_TOKEN }}
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.13
+
+* fix LSS baudrate configuration handling
+* provide LSS store configuration functionality (bitrate and node id)
+
 # 0.4.12
 
 * update object dictionary on type change in PDOs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.4.13
+# 0.5.0
 
 * fix LSS baudrate configuration handling
 * provide LSS store configuration functionality (bitrate and node id)

--- a/src/durand/services/lss.py
+++ b/src/durand/services/lss.py
@@ -18,15 +18,15 @@ class LSSState(IntEnum):
 
 
 class LSSSlave:
-    CiA_bit_timing_table = {  # in kBit
-        0: 1000,
-        1: 800,
-        2: 500,
-        3: 250,
-        4: 125,
-        6: 50,
-        7: 20,
-        8: 10,
+    CiA_bit_timing_table = {
+        0: 1000000,
+        1: 800000,
+        2: 500000,
+        3: 250000,
+        4: 125000,
+        6: 50000,
+        7: 20000,
+        8: 10000,
     }
 
     def __init__(self, node: "Node"):
@@ -150,7 +150,7 @@ class LSSSlave:
             self._node.network.send(0x7E4, b"\x13\x01" + bytes(6))
             return
 
-        self._pending_baudrate = self.CiA_bit_timing_table[index] * 1000  # [kBit/s] -> [Bit/s]
+        self._pending_baudrate = self.CiA_bit_timing_table[index]
         self._node.network.send(0x7E4, b"\x13\x00" + bytes(6))
 
     def cmd_activate_bit_timing(self, msg: bytes):

--- a/src/durand/services/lss.py
+++ b/src/durand/services/lss.py
@@ -47,9 +47,18 @@ class LSSSlave:
         node.nmt.state_callbacks.add(self.on_nmt_state_update)
 
     def set_baudrate_change_callback(self, cb: Callable[[int, float], None]):
+        """Defines a callback function to change bitrate. The delay is obtained from
+        the `activate_bit_timing` command.
+        This callback is called after the delay specified in the command and should
+        change the bitrate of the network after waiting for the delay again.
+        :param cb: callback function with signature (baudrate, delay)
+        """
         self._change_baudrate_cb = cb
 
     def set_store_configuration_callback(self, cb: Callable[[int, int], None]):
+        """Defines a callback function to store new bitrate and node id persistently.
+        :param cb: callback function with signature (baudrate, node_id)
+        """
         self._store_configuration_cb = cb
 
     def on_nmt_state_update(self, state: StateEnum):

--- a/tests/example_based/test_lss.py
+++ b/tests/example_based/test_lss.py
@@ -2,7 +2,7 @@
 
 from durand import Node, scheduler
 
-from ..mock_network import MockNetwork, TxMsg, RxMsg
+from ..mock_network import MockNetwork, RxMsg, TxMsg
 
 
 class MockScheduler(scheduler.AbstractScheduler):
@@ -84,7 +84,7 @@ def test_configuration():
 
     node.lss.set_baudrate_change_callback(baudrate_change_callback)
 
-    def store_configuration_callback(baudrate: int | None, node_id: int | None):
+    def store_configuration_callback(baudrate: int, node_id: int):
         assert baudrate == 500_000
         assert node_id == 2
 

--- a/tests/example_based/test_lss.py
+++ b/tests/example_based/test_lss.py
@@ -1,8 +1,22 @@
 """ Testing LSS service """
 
-from durand import Node
+from durand import Node, scheduler
 
 from ..mock_network import MockNetwork, TxMsg, RxMsg
+
+
+class MockScheduler(scheduler.AbstractScheduler):
+    def add(self, delay: float, callback, args=(), kwargs=None) -> scheduler.TEntry:
+        if kwargs is None:
+            kwargs = {}
+        callback(*args, **kwargs)
+
+    def cancel(self, entry: scheduler.TEntry):
+        ...
+
+    @property
+    def lock(self):
+        ...
 
 
 def test_global_selection():
@@ -36,5 +50,61 @@ def test_global_selection():
             TxMsg(0x701, "00"),  # responder responses with Boot Up message
             RxMsg(0x601, "40 00 10 00 00 00 00 00"),  # requesting via SDO on node 1
             TxMsg(0x581, "43 00 10 00 00 00 00 00"),  # receive the acknowledge
+        ]
+    )
+
+
+def test_configuration():
+    """Test example starts with a node with node id 0x01.
+    After the "switch state global" request to set every responder into configuration mode,
+    the node id is set to 2.
+
+    Furthermore, the baudrate is set to 500 kbit/s and the configuration is stored.
+    When the configuration is stored, the node sends an acknowledge message.
+
+    At last, activate bit timing is sent to the node. It is the responsibility of its callback
+    to reinitialize the network with the new baudrate after a delay.
+    The callback is tested with the baudrate and delay parameters.
+    """
+
+    scheduler_ = MockScheduler()
+    scheduler.set_scheduler(scheduler_)
+
+    network = MockNetwork()
+
+    # create the node
+    node = Node(network, node_id=0x01)
+
+    def baudrate_change_callback(baudrate: int, delay: float):
+        # This callback is supposed to reinitialize the network with the new baudrate
+        # after the delay
+        # In this test, we just check if the callback is called with the correct parameters
+        assert baudrate == 500_000
+        assert delay == 1
+
+    node.lss.set_baudrate_change_callback(baudrate_change_callback)
+
+    def store_configuration_callback(baudrate: int | None, node_id: int | None):
+        assert baudrate == 500_000
+        assert node_id == 2
+
+    node.lss.set_store_configuration_callback(store_configuration_callback)
+
+    network.test(
+        [
+            RxMsg(
+                0x7E5, "04 01 00 00 00 00 00 00"
+            ),  # switch state global to configuration state
+
+            RxMsg(0x7E5, "11 02 00 00 00 00 00 00"),  # set node id to 2
+            TxMsg(0x7E4, "11 00 00 00 00 00 00 00"),  # receive the acknowledge (success)
+
+            RxMsg(0x7E5, "13 00 02 00 00 00 00 00"),  # set baudrate to 500 kbit/s
+            TxMsg(0x7E4, "13 00 00 00 00 00 00 00"),  # receive the acknowledge (success)
+
+            RxMsg(0x7E5, "17 00 00 00 00 00 00 00"),  # store configuration
+            TxMsg(0x7E4, "17 00 00 00 00 00 00 00"),  # receive the acknowledge (success)
+
+            RxMsg(0x7E5, "15 E8 03 00 00 00 00 00"),  # activate bit timing
         ]
     )


### PR DESCRIPTION
## Fixes (to be discussed):
Do not add the NMT reset to the scheduler after calling the `activate_bit_timing` command. When changing the bitrate on an OS (e.g., using `socketcan`, we have to reinitialize everything and thus stop the scheduler.

## Features
Provide the possibility to set a store configuration callback, to store newly set bitrate and node ID persistently. If it's not provided, the command still replies with the not supported value.

## Remarks
I'll add additional LSS test if we agree to a final solution